### PR TITLE
rbuildignore - dot to escaped dot

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,5 +3,5 @@
 ^_pkgdown\.yml$
 ^Jenkinsfile$
 README.*
-^staged_dependencies.yaml$
+^staged_dependencies\.yaml$
 ^LICENSE\.md$


### PR DESCRIPTION
Update .Rbuildignore for ^stage_dependencies\\.yaml$.

Dot was not escaped