### PR TITLE
clear check - scda

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,6 +1,6 @@
 .onAttach <- function(libname, pkgname) { # nolint
   scda_lookup <- paste0("scda.", seq(2020, 2030))
-  is_scdax <- any(sapply(scda_lookup, function(x) length(find.package(x, quiet = TRUE)) > 0))
+  is_scdax <- any(vapply(scda_lookup, function(x) length(find.package(x, quiet = TRUE)) > 0, logical(1)))
   packageStartupMessage(
     if (!is_scdax) {
       paste0(


### PR DESCRIPTION
closes #57 

clear check for scda package.

?.onAttach

"here should be no calls to installed.packages in startup code:"

a new solution to check existence of scda.XXXX packages applied, to not use installed.packages.

"Loading a namespace should where possible be silent, with startup messages given by .onAttach."

so i updated .onLoad to .onAttach, now we print the message only if a library call is used